### PR TITLE
Fallback to first certificate JWK missing Alg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 
 go:
   - "1.13.x"
-  - "master"
 
 env:
   - GO111MODULE=on


### PR DESCRIPTION
Some certificate stores do not provide a value for Alg, so read it from
the first certificate in the chain in those cases.