### PR TITLE
Fix Denial of Service bug equivalent to CVE-2025-27144

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -87,18 +87,18 @@ func intersection(first []jose.KeyOps, second []jose.KeyOps) []jose.KeyOps {
 	return result
 }
 
-//LoadPrivateKey loads the jwk into a crypto.Signer for performing signing operations
+// LoadPrivateKey loads the jwk into a crypto.Signer for performing signing operations
 func LoadPrivateKey(jwk jose.Jwk, required []jose.KeyOps) (crypto.Signer, error) {
 	privateKeyAlgs := map[jose.Alg]bool{
-		jose.AlgRS256: true,
-		jose.AlgRS384: true,
-		jose.AlgRS512: true,
-		jose.AlgPS256: true,
-		jose.AlgPS384: true,
-		jose.AlgPS512: true,
-		jose.AlgES256: true,
-		jose.AlgES384: true,
-		jose.AlgES512: true,
+		jose.AlgRS256:   true,
+		jose.AlgRS384:   true,
+		jose.AlgRS512:   true,
+		jose.AlgPS256:   true,
+		jose.AlgPS384:   true,
+		jose.AlgPS512:   true,
+		jose.AlgES256:   true,
+		jose.AlgES384:   true,
+		jose.AlgES512:   true,
 		jose.AlgRSAOAEP: true,
 	}
 
@@ -149,18 +149,18 @@ func LoadPrivateKey(jwk jose.Jwk, required []jose.KeyOps) (crypto.Signer, error)
 	}
 }
 
-//LoadPublicKey loads jwk as a public key for cryptographic verification operations.
+// LoadPublicKey loads jwk as a public key for cryptographic verification operations.
 func LoadPublicKey(jwk jose.Jwk, required []jose.KeyOps) (crypto.PublicKey, error) {
 	publicKeyAlgs := map[jose.Alg]bool{
-		jose.AlgRS256: true,
-		jose.AlgRS384: true,
-		jose.AlgRS512: true,
-		jose.AlgPS256: true,
-		jose.AlgPS384: true,
-		jose.AlgPS512: true,
-		jose.AlgES256: true,
-		jose.AlgES384: true,
-		jose.AlgES512: true,
+		jose.AlgRS256:   true,
+		jose.AlgRS384:   true,
+		jose.AlgRS512:   true,
+		jose.AlgPS256:   true,
+		jose.AlgPS384:   true,
+		jose.AlgPS512:   true,
+		jose.AlgES256:   true,
+		jose.AlgES384:   true,
+		jose.AlgES512:   true,
 		jose.AlgRSAOAEP: true,
 	}
 	if _, ok := publicKeyAlgs[jwk.Alg()]; !ok {
@@ -199,10 +199,10 @@ func LoadPublicKey(jwk jose.Jwk, required []jose.KeyOps) (crypto.PublicKey, erro
 	}
 }
 
-//LoadJws loads signature, or errors
+// LoadJws loads signature, or errors
 func LoadJws(jws string) (protectedHeader *jose.JwsHeader, header []byte, data []byte, payload []byte, signature []byte, err error) {
 	var tmp jose.JwsHeader
-	parts := strings.Split(jws, ".")
+	parts := strings.SplitN(jws, ".", 3)
 	if len(parts) != 3 {
 		return nil, nil, nil, nil, nil, ErrInvalidJwsCompactEncoding
 	}
@@ -226,7 +226,7 @@ func LoadJws(jws string) (protectedHeader *jose.JwsHeader, header []byte, data [
 	return
 }
 
-//CalculateKeyID deterministically calculates the ID for the given jwk
+// CalculateKeyID deterministically calculates the ID for the given jwk
 func CalculateKeyID(jwk jose.Jwk) (string, error) {
 	/* Deterministic calculation of a jwk's identity. */
 	switch typed := jwk.(type) {
@@ -278,7 +278,7 @@ func CalculateKeyID(jwk jose.Jwk) (string, error) {
 	}
 }
 
-//LoadJwk load io.ReadSeeker as a JWK or error
+// LoadJwk load io.ReadSeeker as a JWK or error
 func LoadJwk(reader io.ReadSeeker, required []jose.KeyOps) (jwk jose.Jwk, err error) {
 	if jwk, err = jose.UnmarshalJwk(reader); err != nil {
 		return
@@ -289,7 +289,7 @@ func LoadJwk(reader io.ReadSeeker, required []jose.KeyOps) (jwk jose.Jwk, err er
 	return
 }
 
-//LoadJwkFromFile loads file as JWK or error
+// LoadJwkFromFile loads file as JWK or error
 func LoadJwkFromFile(file string, required []jose.KeyOps) (jose.Jwk, error) {
 	/* Load jwk from file. */
 	fd, err := os.Open(file)
@@ -308,7 +308,8 @@ var inverseOps = map[jose.KeyOps]jose.KeyOps{
 }
 
 // TODO this method always return PS algortihm for signature but never RSA alg for encryption.
-//  need to find a way to return encryption alg
+//
+//	need to find a way to return encryption alg
 func rsaBitsToAlg(bitLen int) jose.Alg {
 	/* Based on NIST recommendations from 2016. */
 	if bitLen >= 15360 {
@@ -332,7 +333,7 @@ func ecBitsToAlg(bitLen int) jose.Alg {
 	}
 }
 
-//PublicFromPrivate extracts public jwk from private jwk in JWK format
+// PublicFromPrivate extracts public jwk from private jwk in JWK format
 func PublicFromPrivate(in jose.Jwk) (jose.Jwk, error) {
 	var out jose.Jwk
 	switch k := in.(type) {
@@ -363,7 +364,7 @@ func PublicFromPrivate(in jose.Jwk) (jose.Jwk, error) {
 	return out, nil
 }
 
-//JwkToString return JWK as string
+// JwkToString return JWK as string
 func JwkToString(jwk jose.Jwk) (string, error) {
 	b, err := json.Marshal(jwk)
 	if err != nil {
@@ -396,7 +397,7 @@ func concatByteArrays(slices [][]byte) []byte {
 	return tmp
 }
 
-//JwkFromPrivateKey builds JWK, from a crypto.Signer, with certificates, and scoped to certain operations,  or errors
+// JwkFromPrivateKey builds JWK, from a crypto.Signer, with certificates, and scoped to certain operations,  or errors
 func JwkFromPrivateKey(privateKey crypto.Signer, operations []jose.KeyOps, certs []*x509.Certificate) (jose.Jwk, error) {
 	var jwk jose.Jwk
 	switch v := privateKey.(type) {
@@ -449,7 +450,7 @@ func JwkFromPrivateKey(privateKey crypto.Signer, operations []jose.KeyOps, certs
 	return jwk, nil
 }
 
-//JwkFromPublicKey builds public JWK, from a crypto.Signer, with certificates, and scoped to certain operations,  or errors
+// JwkFromPublicKey builds public JWK, from a crypto.Signer, with certificates, and scoped to certain operations,  or errors
 func JwkFromPublicKey(publicKey crypto.PublicKey, operations []jose.KeyOps, certs []*x509.Certificate) (jose.Jwk, error) {
 	var jwk jose.Jwk
 	switch v := publicKey.(type) {

--- a/jose/jwe.go
+++ b/jose/jwe.go
@@ -174,7 +174,7 @@ func (jweHeader *HeaderRfc7516) MarshallHeader() (marshalledHeader []byte, err e
 // DEPRECATED : does not match the proper JWE structure as defined in rfc 7516
 func (jwe *Jwe) Unmarshal(src string) (err error) {
 	/* Compact JWS encoding. */
-	parts := strings.Split(src, ".")
+	parts := strings.SplitN(src, ".", 5)
 	if len(parts) != 5 {
 		err = ErrJweFormat
 		return
@@ -211,7 +211,7 @@ func (jwe *JweRfc7516Compact) Unmarshal(src string) (err error) {
 	//   o  Initialization Vector
 	//   o  Ciphertext
 	//   o  Authentication Tag
-	parts := strings.Split(src, ".")
+	parts := strings.SplitN(src, ".", 5)
 	if len(parts) != 5 {
 		err = ErrJweFormat
 		return

--- a/jose/jws.go
+++ b/jose/jws.go
@@ -124,7 +124,7 @@ func (jws *Jws) Body() (body string, err error) {
 //Unmarshal to body string, or error
 func (jws *Jws) Unmarshal(src string) (body string, err error) {
 	/* Compact JWS encoding. */
-	parts := strings.Split(src, ".")
+	parts := strings.SplitN(src, ".", 3)
 	if len(parts) != 3 {
 		err = ErrJwtFormat
 		return

--- a/jwe_key_encryption_decryptor_test.go
+++ b/jwe_key_encryption_decryptor_test.go
@@ -47,7 +47,7 @@ func generateDecryptor(t *testing.T) (decryptor *JweRsaKeyEncryptionDecryptorImp
 // Known answer test (KAT). See https://tools.ietf.org/html/rfc7516#appendix-A.1
 func TestJweRsaKeyEncryptionDecryptorImpl_Decrypt_KAT(t *testing.T) {
 	decryptor := generateDecryptor(t)
-	pt, aad, err := decryptor.Decrypt(oaepJweFromSpec, crypto.SHA256)
+	pt, aad, err := decryptor.Decrypt(oaepJweFromSpec, crypto.SHA1)
 	require.NoError(t, err)
 	assert.Equal(t, "The true sign of intelligence is not knowledge but imagination.", string(pt))
 	assert.Len(t, aad, 46)

--- a/jwks_truststore.go
+++ b/jwks_truststore.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ThalesGroup/gose/jose"
 )
@@ -132,6 +133,9 @@ func NewJwksKeyStore(issuerList, url string) *JwksTrustStore {
 	return &JwksTrustStore{
 		url:          url,
 		inputIssuers: issuerList,
-		client:       http.DefaultClient,
+		client:       &http.Client {
+			// TODO: modify Get method to accept a context to manage timeouts.
+			Timeout: time.Second * 30,
+		},
 	}
 }


### PR DESCRIPTION

#### Proposed Changes ####

This change fixes a denial of service bug equivalent to CVE-2025-27144 in the go-jose package.

The issue is that a malicious attacker could present JWTs and JWEs with excessive dot separators. The existing implementation is subject to excessive memory usage due to the use of the `strings.Split` function which will continue to split compact-encoded JWTs and JWEs beyond the expected number. It is expected that the severity of this issue is low.

Secondly, this PR adds a timeout to the internal JWKS fetcher. Previously, the original solution used the default getter from the Go standard `http` package which has an unlimited timeout. A malicious JWKS server could keep a connection alive indefinitely and never return stalling a Go routine forever. This could lead to resource exhaustion and DoS conditions. Given a JWKS URL is most often configured as trusted, this is also a low severity issue.

Finally, this PR fixes a broken unit test swapping SHA256/SHA1 in a known answer test.

#### Types of Changes ####

Bugfix

#### Verification ####

Re-run unit tests.

#### Testing ####

Re-run existing unit tests

#### Linked Issues ####

https://github.com/go-jose/go-jose/commit/99b346cec4e86d102284642c5dcbe9bb0cacfc22

#### User-Facing Change ####

```release-note
None
```

#### Further Comments ####

